### PR TITLE
復元度合い調べるコマンドの実行方法を変更した

### DIFF
--- a/measure/lsexec/ls_exec.go
+++ b/measure/lsexec/ls_exec.go
@@ -33,24 +33,11 @@ func run(args []string, out io.Writer) error {
 
 	imageID := args[0]
 
-	shellScript := fmt.Sprintf(`#!/bin/sh
-docker run --rm %s /bin/sh -c "find %s -type f -ls" | awk '{ print $11, $7 }'`, imageID, targetDir)
-
-	file, err := os.CreateTemp("/tmp", "*.sh")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(file.Name())
-
-	_, err = file.WriteString(shellScript)
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command("sh", file.Name())
+	cmdOnContainer := fmt.Sprintf("cd %s && find . -type f -ls | awk '{ print $11, $7 }'", targetDir)
+	cmd := exec.Command("docker", "run", "--rm", imageID, "/bin/sh", "-c", cmdOnContainer)
 	cmd.Stdout = out
 
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("faild to exec command: %w", err)
 	}


### PR DESCRIPTION
#9 の修正

このコマンドをコンテナ上で実行するようになった
```shell
cd {対象ディレクトリ} && find . -type f -ls | awk '{ print $11, $7 }'
```

判定コードの実行例
```shell
$ go run ./lsexec --targetDir={findを実行するディレクトリ} {imageA} > ./out/a
$ go run ./lsexec --targetDir={findを実行するディレクトリ} {imageB} > ./out/b
$ go run ./matchrate ./out/a ./out/b
file A: ./out/a
file B: ./out/b

それぞれのパスの数
        A: 20
        B: 25

一致しているパスの数: 18
データサイズも一致しているパスの数: 10
```