### PR TITLE
check-pkgコマンドに比較対象にimageを指定できるようにした

### DIFF
--- a/cli/checkpkg/check_pkg_test.go
+++ b/cli/checkpkg/check_pkg_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_checkPackageInformation(t *testing.T) {
-	got, err := checkPackageInformation("testdata/Dockerfile")
+	got, err := checkPackageInformation("testdata/Dockerfile", nil)
 	require.NoError(t, err)
 
 	require.Len(t, got, 2)


### PR DESCRIPTION
`--imageID`フラグで指定可能