### PR TITLE
docker v25対応の修正

### DIFF
--- a/cli/restorecopy/restore_copy.go
+++ b/cli/restorecopy/restore_copy.go
@@ -90,7 +90,7 @@ func embodyCopiedObjects(targetPath string, copiedObjects []*restorecopy.CopiedO
 
 	for _, copiedObject := range copiedObjects {
 		pathForLayer := filepath.Join(targetPath, copiedObject.LayerID)
-		err := os.Mkdir(pathForLayer, 0777)
+		err := os.MkdirAll(pathForLayer, 0777)
 		if err != nil {
 			return fmt.Errorf("failed to create a directory: %w", err)
 		}

--- a/disassembler/disassembler.go
+++ b/disassembler/disassembler.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"os"
+
 	"github.com/tklab-group/docker-image-disassembler/disassembler/image"
 	"github.com/tklab-group/docker-image-disassembler/disassembler/image/docker"
 	"github.com/tklab-group/docker-image-disassembler/disassembler/pkginfo"
-	"os"
 )
 
 // TODO: Enhance to other package managers
@@ -24,8 +25,15 @@ func GetAptPkgInfoInImageFromImageID(imageID string) (map[string]string, error) 
 	defer os.Remove(imageTarFile.Name())
 
 	err = docker.RunDockerCmd("save", []string{imageID, "-o", imageTarFile.Name()}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to save image: %w", err)
+	}
 
 	imageTarFile, err = os.Open(imageTarFile.Name())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open temp file: %w", err)
+	}
+
 	reader := bufio.NewReader(imageTarFile)
 
 	imageArchive, err := image.NewImageArchive(reader)


### PR DESCRIPTION
#17 での対応漏れを修正した。
具体的には、v25以降では`blobs/`がついている要素でサイズが大きいjsonがあった場合の判定に誤りが発生しており、多くのdockerイメージでconfigファイルが見つからなくなっていた。
先にjson形式か判定し、jsonでなかった場合にtarと判定することでこれを回避するように修正した。
